### PR TITLE
Shortwave 3.2.0 cleanup

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -62,20 +62,13 @@ parts:
     organize:
       snap/shortwave/current: .
     build-packages:
-      - intltool
-      - gettext
-      - gnome-common
       - rustc
       - libssl-dev
-      - appstream
-      - libappstream-glib-dev
-      - libappstream-dev
       - libgstreamer1.0-dev
       - libgstreamer-plugins-base1.0-dev
       - libgstreamer-plugins-bad1.0-dev
       - cargo
       - git
-      - desktop-file-utils
     stage-packages:
       - freeglut3
       - gstreamer1.0-plugins-bad

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -69,65 +69,6 @@ parts:
       - libgstreamer-plugins-bad1.0-dev
       - cargo
       - git
-    stage-packages:
-      - freeglut3
-      - gstreamer1.0-plugins-bad
-      - gstreamer1.0-plugins-base
-      - gstreamer1.0-plugins-good
-      - gstreamer1.0-plugins-ugly
-      - liba52-0.7.4
-      - libaom3
-      - libass9
-      - libbs2b0
-      - libcdio19
-      - libchromaprint1
-      - libdc1394-25
-      - libdca0
-      - libde265-0
-      - libdvdnav4
-      - libdvdread8
-      - libfaad2
-      - libflite1
-      - libfluidsynth3
-      - libfreeaptx0
-      - libgl1
-      - libglu1-mesa
-      - libglvnd0
-      - libglx0
-      - libgme0
-      - libgsm1
-      - libgstreamer-plugins-bad1.0-0
-      - libgstreamer-plugins-base1.0-0
-      - libgstreamer1.0-0
-      - libkate1
-      - libldacbt-enc2
-      - liblilv-0-0
-      - libltc11
-      - libmjpegutils-2.1-0
-      - libmodplug1
-      - libmpcdec6
-      - libmpeg2-4
-      - libopenal1
-      - libopencore-amrnb0
-      - libopencore-amrwb0
-      - libopenexr25
-      - libopenh264-6
-      - libopenni2-0
-      - liborc-0.4-0
-      - libqrencode4
-      - libsbc1
-      - libsidplay1v5
-      - libsoundtouch1
-      - libspandsp2
-      - libsrt1.4-gnutls
-      - libsrtp2-1
-      - libusb-1.0-0
-      - libvo-aacenc0
-      - libvo-amrwbenc0
-      - libx264-163
-      - libx265-199
-      - libzbar0
-      - libzvbi0
     override-pull: |
       craftctl default
       # snapd can't use a name like de.haeckerfelix.Shortwave for mpris
@@ -139,5 +80,25 @@ parts:
       craftctl default
       # Fix-up application icon lookup
       sed -i.bak -e 's|^Icon=.*|Icon=${SNAP}/usr/share/icons/hicolor/scalable/apps/de.haeckerfelix.Shortwave.svg|' usr/share/applications/de.haeckerfelix.Shortwave.desktop
-      # Use the Gnome extension's version
-      rm -f usr/lib/*/libharfbuzz.so*
+
+  gstreamer-plugins:
+    plugin: nil
+    build-snaps:
+      - core22
+      - gnome-42-2204
+    stage-packages:
+      - gstreamer1.0-plugins-bad
+      - gstreamer1.0-plugins-base
+      - gstreamer1.0-plugins-good
+      - gstreamer1.0-plugins-ugly
+    override-build: |
+      set -eux
+      craftctl default
+      for snap in "core22" "gnome-42-2204"; do
+        cd /snap/$snap/current/usr/lib/$CRAFT_ARCH_TRIPLET
+        find . -type f,l -name "*.so*" -exec bash -c "rm -f $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET/{}*" \;
+      done
+    prime:
+      - usr/lib/$CRAFT_ARCH_TRIPLET/*.so*
+      - usr/lib/$CRAFT_ARCH_TRIPLET/*/*.so*
+


### PR DESCRIPTION
Removes build-packages and libraries from stage-packages which already get provided by the base snap or the gnome extension.

PS: It also looks possible to get rid of the other *-dev build-packages in the shortwave snap by patching out some of the dependency checks in shortwave's meson.build. Looks like nothing is done with them but checking for existence.
But since I fail to see how it would impact the resulting snap, I have not bothered to try it out. For now, that is ;-)